### PR TITLE
fix: allow authorization header for cross-origin

### DIFF
--- a/dockereve-master/eve-app/settings.py
+++ b/dockereve-master/eve-app/settings.py
@@ -172,6 +172,7 @@ settings = {
     'RESOURCE_METHODS': ['GET', 'POST'],
     'ITEM_METHODS': ['GET'],
     'X_DOMAINS': '*',
+    'X_HEADERS': ['Authorization','Content-type'],
     'DOMAIN': {
         'image': {
             'item_title': 'image',


### PR DESCRIPTION
based on https://stackoverflow.com/questions/27950344/python-eve-no-access-control-allow-origin-header-is-present-on-the-requested

not sure if this will work!